### PR TITLE
Fix chunk_size to be 1000 tokens, not characters

### DIFF
--- a/langchain_helper.py
+++ b/langchain_helper.py
@@ -16,7 +16,7 @@ def create_db_from_youtube_video_url(video_url: str) -> FAISS:
     loader = YoutubeLoader.from_youtube_url(video_url)
     transcript = loader.load()
 
-    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=100)
+    text_splitter = RecursiveCharacterTextSplitter.from_tiktoken_encoder(chunk_size=1000, chunk_overlap=100)
     docs = text_splitter.split_documents(transcript)
 
     db = FAISS.from_documents(docs, embeddings)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ openai
 youtube-transcript-api
 faiss-cpu
 streamlit
+tiktoken


### PR DESCRIPTION
Hello, my friend. Thank you for the video and for repository.
When we use just `RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=100)`, then chunks contain up to 1000 characters, not tokens. You told in video and there is written in the code, that one chunk has 1000 tokens. To make so, we can use `RecursiveCharacterTextSplitter.from_tiktoken_encoder(chunk_size=1000, chunk_overlap=100)` with installed tiktoken library. Then we will have ~1000 tokens in one chunk.