### PR TITLE
Request to merge the following minor improvements:

### DIFF
--- a/langchain_helper.py
+++ b/langchain_helper.py
@@ -9,21 +9,21 @@ from dotenv import load_dotenv
 
 
 load_dotenv()
-embeddings = OpenAIEmbeddings()
 
 
-def create_db_from_youtube_video_url(video_url: str) -> FAISS:
+def create_db_from_youtube_video_url(video_url: str,openai_api_key) -> FAISS:
     loader = YoutubeLoader.from_youtube_url(video_url)
     transcript = loader.load()
 
     text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=100)
     docs = text_splitter.split_documents(transcript)
 
+    embeddings = OpenAIEmbeddings(openai_api_key=openai_api_key)
     db = FAISS.from_documents(docs, embeddings)
     return db
 
 
-def get_response_from_query(db, query, k=4):
+def get_response_from_query(db, query, openai_api_key, k=4):
     """
     text-davinci-003 can handle up to 4097 tokens. Setting the chunksize to 1000 and k to 4 maximizes
     the number of tokens to analyze.
@@ -32,7 +32,7 @@ def get_response_from_query(db, query, k=4):
     docs = db.similarity_search(query, k=k)
     docs_page_content = " ".join([d.page_content for d in docs])
 
-    llm = OpenAI(model_name="text-davinci-003")
+    llm = OpenAI(model_name="text-davinci-003",openai_api_key=openai_api_key)
 
     prompt = PromptTemplate(
         input_variables=["question", "docs"],

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ with st.sidebar:
     with st.form(key='my_form'):
         youtube_url = st.sidebar.text_area(
             label="What is the YouTube video URL?",
-            max_chars=50
+            max_chars=150
             )
         query = st.sidebar.text_area(
             label="Ask me about the video?",
@@ -18,7 +18,7 @@ with st.sidebar:
         openai_api_key = st.sidebar.text_input(
             label="OpenAI API Key",
             key="langchain_search_api_key_openai",
-            max_chars=50,
+            max_chars=150,
             type="password"
             )
         "[Get an OpenAI API key](https://platform.openai.com/account/api-keys)"
@@ -30,7 +30,7 @@ if query and youtube_url:
         st.info("Please add your OpenAI API key to continue.")
         st.stop()
     else:
-        db = lch.create_db_from_youtube_video_url(youtube_url)
-        response, docs = lch.get_response_from_query(db, query)
+        db = lch.create_db_from_youtube_video_url(youtube_url,openai_api_key)
+        response, docs = lch.get_response_from_query(db, query,openai_api_key)
         st.subheader("Answer:")
         st.text(textwrap.fill(response, width=85))


### PR DESCRIPTION
- openai_api_key was asked in main.py but not passed along when needed. The user had to both pass it in the code and UI. Now the user can pass it only in the UI.

- To allow the user to only pass their openai_api_key in the UI and even be able to run the UI, the embeddings had to go inside the create_db_from_youtube_video_url function. With this change, the user is now able to only interact with the UI and not get any wired errors.

- Lastly, I increased the number of char allowed for the openai_api_key and the yt url, since the openai_api_key is longer than 50 chars and so are some yt_urls. In those cases when the user tries to paste their string, is not allowed. I increased the limit to 150 chars.